### PR TITLE
Update session create

### DIFF
--- a/bindings/python/src/backend.py
+++ b/bindings/python/src/backend.py
@@ -7,7 +7,7 @@ def create_session(path, use_cuda):
     # if use_cuda=True force it to error if GPU is not available
     
     if use_cuda is None:
-        providers = [provider for provider in ["CUDAExecutionProvider", "CPUExecutionProvider"] if provider in onnxruntime.get_availabile_providers()]
+        providers = [provider for provider in ["CUDAExecutionProvider", "CPUExecutionProvider"] if provider in onnxruntime.get_available_providers()]
     else:
         if use_cuda:
             providers = ["CUDAExecutionProvider"]

--- a/bindings/python/src/backend.py
+++ b/bindings/python/src/backend.py
@@ -5,9 +5,13 @@ from tqdm.auto import tqdm
 def create_session(path, use_cuda):
     # onnxruntime automatically prioritizes GPU if supported
     # if use_cuda=True force it to error if GPU is not available
-    providers = ["CPUExecutionProvider"]
-    if use_cuda:
-        providers = ["CUDAExecutionProvider"]
+    providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
+    if use_cuda is not None:
+        if use_cuda:
+            providers = ["CUDAExecutionProvider"]
+        else:
+            providers = ["CPUExecutionProvider"]
+
     session = onnxruntime.InferenceSession(path, providers=providers)
 
     return session

--- a/bindings/python/src/backend.py
+++ b/bindings/python/src/backend.py
@@ -3,15 +3,12 @@ from tqdm.auto import tqdm
 
 
 def create_session(path, use_cuda):
-    session = onnxruntime.InferenceSession(path)
-
     # onnxruntime automatically prioritizes GPU if supported
     # if use_cuda=True force it to error if GPU is not available
-    if use_cuda is not None:
-        if use_cuda:
-            session.set_providers(["CUDAExecutionProvider"])
-        else:
-            session.set_providers(["CPUExecutionProvider"])
+    providers = ["CPUExecutionProvider"]
+    if use_cuda:
+        providers = ["CUDAExecutionProvider"]
+    session = onnxruntime.InferenceSession(path, providers=providers)
 
     return session
 

--- a/bindings/python/src/backend.py
+++ b/bindings/python/src/backend.py
@@ -5,8 +5,10 @@ from tqdm.auto import tqdm
 def create_session(path, use_cuda):
     # onnxruntime automatically prioritizes GPU if supported
     # if use_cuda=True force it to error if GPU is not available
-    providers = ["CUDAExecutionProvider", "CPUExecutionProvider"]
-    if use_cuda is not None:
+    
+    if use_cuda is None:
+        providers = [provider for provider in ["CUDAExecutionProvider", "CPUExecutionProvider"] if provider in onnxruntime.get_availabile_providers()]
+    else:
         if use_cuda:
             providers = ["CUDAExecutionProvider"]
         else:


### PR DESCRIPTION
onnxruntime has deprecated creating a session without setting a provider at creation time (the latest version fails). This PR fixes the session creation. 